### PR TITLE
Environment trait + tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,13 +586,26 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.2",
  "rand_hc",
 ]
 
@@ -597,8 +616,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.2",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -615,7 +649,16 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.2",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -752,6 +795,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,7 +812,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand",
+ "rand 0.8.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -947,6 +1000,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "structopt",
+ "tempdir",
  "tokio",
  "toml",
  "ya-runtime-api",

--- a/examples/example-runtime/src/main.rs
+++ b/examples/example-runtime/src/main.rs
@@ -53,11 +53,7 @@ impl Runtime for ExampleRuntime {
     }
 }
 
-// Macro expansion is equivalent to:
-//
-// #[tokio::main]
-// async fn main() -> anyhow::Result<()> {
-//     ya_runtime_sdk::::run::<ExampleRuntime>().await
-// }
-
-main!(ExampleRuntime);
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    ya_runtime_sdk::run::<ExampleRuntime>().await
+}

--- a/ya-runtime-sdk/Cargo.toml
+++ b/ya-runtime-sdk/Cargo.toml
@@ -16,9 +16,12 @@ features = ["codec"]
 git = "https://github.com/golemfactory/yagna.git"
 rev = "3d0bee5c12ce64bdb68f11c765f77eab762984ab"
 
-[dependencies]
-ya-runtime-sdk-derive = { version = "0.1", path = "../ya-runtime-sdk-derive", optional = true }
+[dependencies.ya-runtime-sdk-derive]
+version = "0.1"
+path = "../ya-runtime-sdk-derive"
+optional = true
 
+[dependencies]
 anyhow = "1.0"
 directories = "3.0"
 futures = "0.3"
@@ -28,3 +31,6 @@ serde_yaml = "0.8"
 structopt = "0.3"
 tokio = { version = "0.2", features = ["io-std", "io-util", "rt-core", "rt-threaded", "macros"] }
 toml = "0.5"
+
+[dev-dependencies]
+tempdir = "0.3"

--- a/ya-runtime-sdk/src/cli.rs
+++ b/ya-runtime-sdk/src/cli.rs
@@ -6,7 +6,7 @@ pub trait CommandCli: StructOpt {
     fn command(&self) -> &Command;
 }
 
-#[derive(Clone, Debug, StructOpt)]
+#[derive(Clone, Debug, Eq, PartialEq, StructOpt)]
 #[structopt(setting = clap::AppSettings::DeriveDisplayOrder)]
 pub enum Command {
     /// Deploy the runtime

--- a/ya-runtime-sdk/src/env.rs
+++ b/ya-runtime-sdk/src/env.rs
@@ -1,0 +1,31 @@
+use std::path::PathBuf;
+
+const ORGANIZATION: &'static str = "GolemFactory";
+
+/// Runtime environment configuration
+pub trait Env {
+    /// Directory to store the configuration, caches and state at
+    fn data_directory(&self, runtime_name: &str) -> anyhow::Result<PathBuf>;
+
+    /// Command line arguments
+    fn args(&self) -> Box<dyn Iterator<Item = String>> {
+        Box::new(std::env::args())
+    }
+}
+
+/// Default runtime environment provider.
+///
+/// - data directory is located in the home user folder
+/// - provides unaltered command line arguments
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DefaultEnv;
+
+impl Env for DefaultEnv {
+    fn data_directory(&self, runtime_name: &str) -> anyhow::Result<PathBuf> {
+        Ok(
+            directories::ProjectDirs::from("", ORGANIZATION, runtime_name)
+                .map(|dirs| dirs.data_dir().into())
+                .unwrap_or_else(|| PathBuf::from(ORGANIZATION).join(runtime_name)),
+        )
+    }
+}

--- a/ya-runtime-sdk/src/lib.rs
+++ b/ya-runtime-sdk/src/lib.rs
@@ -1,19 +1,17 @@
-pub mod cli;
-pub mod error;
-pub mod runner;
-mod runtime;
-pub mod serialize;
-mod server;
-
 pub use ya_runtime_api as runtime_api;
-pub use ya_runtime_api::server::{
-    ErrorResponse, KillProcess, ProcessStatus, RunProcess, RuntimeEvent,
-};
+pub use ya_runtime_api::server::{ErrorResponse, KillProcess, ProcessStatus, RunProcess};
 
 pub use cli::Command;
-pub use runner::{run, RuntimeMode};
+pub use runner::{run, run_with};
 pub use runtime::*;
-pub use server::Server;
+
+pub mod cli;
+pub mod env;
+pub mod error;
+mod runner;
+mod runtime;
+pub mod serialize;
+pub mod server;
 
 #[cfg(feature = "macros")]
 #[allow(unused_imports)]
@@ -22,14 +20,3 @@ extern crate ya_runtime_sdk_derive;
 #[cfg(feature = "macros")]
 #[doc(hidden)]
 pub use ya_runtime_sdk_derive::*;
-
-#[cfg(feature = "macros")]
-#[macro_export]
-macro_rules! main {
-    ($ty:ty) => {
-        #[tokio::main]
-        async fn main() -> anyhow::Result<()> {
-            ya_runtime_sdk::run::<$ty>().await
-        }
-    };
-}

--- a/ya-runtime-sdk/src/server.rs
+++ b/ya-runtime-sdk/src/server.rs
@@ -1,10 +1,13 @@
-use crate::{Context, Runtime, RuntimeDef, RuntimeMode};
-use futures::{FutureExt, TryFutureExt};
 use std::cell::RefCell;
 use std::rc::Rc;
+
+use futures::{FutureExt, TryFutureExt};
 use ya_runtime_api::server::{
     AsyncResponse, KillProcess, RunProcess, RunProcessResp, RuntimeService,
 };
+
+use crate::runtime::RuntimeMode;
+use crate::{Context, Runtime, RuntimeDef};
 
 pub struct Server<R: Runtime> {
     pub(crate) runtime: Rc<RefCell<R>>,

--- a/ya-runtime-sdk/tests/context.rs
+++ b/ya-runtime-sdk/tests/context.rs
@@ -1,0 +1,128 @@
+mod utils;
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use ya_runtime_sdk::*;
+
+#[derive(structopt::StructOpt)]
+#[structopt(rename_all = "kebab-case")]
+pub struct Cli {
+    #[structopt(long)]
+    param: usize,
+}
+
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq)]
+pub struct Conf {
+    numeric: i64,
+    string: String,
+    vec: Vec<String>,
+}
+
+impl Default for Conf {
+    fn default() -> Self {
+        Conf {
+            numeric: 42,
+            string: String::from("default value"),
+            vec: vec!["first entry".to_string(), "second entry".to_string()],
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Env {
+    temp_dir: tempdir::TempDir,
+}
+
+impl Default for Env {
+    fn default() -> Self {
+        Self {
+            temp_dir: tempdir::TempDir::new("ya-runtime-sdk")
+                .expect("Cannot create a temp directory"),
+        }
+    }
+}
+
+impl ya_runtime_sdk::env::Env for Env {
+    fn data_directory(&self, _: &str) -> anyhow::Result<PathBuf> {
+        Ok(self.temp_dir.path().to_path_buf())
+    }
+
+    fn args(&self) -> Box<dyn Iterator<Item = String>> {
+        Box::new(
+            vec![
+                env!("CARGO_PKG_NAME").to_string(),
+                "--workdir".to_string(),
+                self.temp_dir.path().display().to_string(),
+                "--param".to_string(),
+                42.to_string(),
+                "deploy".to_string(),
+                "deploy-arg".to_string(),
+            ]
+            .into_iter(),
+        )
+    }
+}
+#[derive(ya_runtime_sdk::RuntimeDef, Default)]
+#[conf(Conf)]
+#[cli(Cli)]
+struct Runtime;
+impl_empty_runtime!(Runtime);
+
+#[test]
+fn context_env() {
+    let env = Env::default();
+    let dir = env.temp_dir.path().to_path_buf();
+
+    let context = Context::<Runtime>::try_with(env).expect("Failed to initialize runtime context");
+    let deploy = Command::Deploy {
+        args: vec!["deploy-arg".to_string()],
+    };
+
+    assert_eq!(context.conf, Conf::default());
+    assert_eq!(context.cli.workdir, Some(dir));
+    assert_eq!(context.cli.runtime.param, 42);
+    assert_eq!(context.cli.command, deploy);
+}
+
+#[test]
+fn conf_file() {
+    let temp_dir = Env::default().temp_dir;
+    let path = temp_dir.path();
+    let conf = Conf::default();
+
+    let check = |ext: &str| {
+        let p = path.join(format!("config.{}", ext));
+
+        Context::<Runtime>::write_config(&conf, &p).expect("Error writing config to file");
+        let read = Context::<Runtime>::read_config(&p).expect("Error reading config from file");
+        std::fs::remove_file(p).expect("Unable to remove file");
+
+        assert_eq!(conf, read);
+    };
+
+    check("json");
+    check("JSON");
+    check("JsoN");
+    check("yaml");
+    check("yml");
+    check("toml");
+}
+
+#[test]
+fn conf_file_err() {
+    let temp_dir = Env::default().temp_dir;
+    let path = temp_dir.path();
+    let conf = Conf::default();
+
+    let write_path = path.join("config.json");
+    Context::<Runtime>::write_config(&conf, &write_path).expect("Error writing config to file");
+
+    let read = Context::<Runtime>::read_config(&write_path);
+    assert_eq!(read.is_ok(), true);
+
+    let renamed_path = path.join("config.toml");
+    std::fs::rename(&write_path, &renamed_path).expect("Failed to rename file");
+
+    let read = Context::<Runtime>::read_config(&renamed_path);
+    assert_eq!(read.is_ok(), false);
+}

--- a/ya-runtime-sdk/tests/utils/mod.rs
+++ b/ya-runtime-sdk/tests/utils/mod.rs
@@ -1,0 +1,36 @@
+#[macro_export]
+macro_rules! impl_empty_runtime {
+    ($ty: ty) => {
+        impl ya_runtime_sdk::Runtime for $ty {
+            fn deploy<'a>(
+                &mut self,
+                _: &mut ya_runtime_sdk::Context<Self>,
+            ) -> ya_runtime_sdk::OutputResponse<'a> {
+                unimplemented!()
+            }
+
+            fn start<'a>(
+                &mut self,
+                _: &mut ya_runtime_sdk::Context<Self>,
+            ) -> ya_runtime_sdk::OutputResponse<'a> {
+                unimplemented!()
+            }
+
+            fn stop<'a>(
+                &mut self,
+                _: &mut ya_runtime_sdk::Context<Self>,
+            ) -> ya_runtime_sdk::EmptyResponse<'a> {
+                unimplemented!()
+            }
+
+            fn run_command<'a>(
+                &mut self,
+                _: ya_runtime_sdk::RunProcess,
+                _: ya_runtime_sdk::RuntimeMode,
+                _: &mut ya_runtime_sdk::Context<Self>,
+            ) -> ya_runtime_sdk::ProcessIdResponse<'a> {
+                unimplemented!()
+            }
+        }
+    };
+}


### PR DESCRIPTION
- `Env` and `DefaultEnv` for customizing the environment (directories / command line args)
- `RuntimeMode` moved from `runner` to `runtime` module
- context and configuration tests
- cleanup crate exports
- drop the `main` macro