### PR TITLE
`run_command` facilitation

### DIFF
--- a/examples/example-runtime/Cargo.toml
+++ b/examples/example-runtime/Cargo.toml
@@ -12,4 +12,4 @@ anyhow = "1.0"
 futures = "0.3"
 serde = { version = "^1.0", features = ["derive"] }
 structopt = "0.3"
-tokio = { version = "0.2", features = ["time", "macros"] }
+tokio = { version = "0.2", features = ["process", "macros", "time"] }

--- a/examples/example-runtime/src/main.rs
+++ b/examples/example-runtime/src/main.rs
@@ -37,8 +37,12 @@ impl Runtime for ExampleRuntime {
     }
 
     fn start<'a>(&mut self, _: &mut Context<Self>) -> OutputResponse<'a> {
-        // Start the service
-        async move { Ok(None) }.boxed_local()
+        async move {
+            Ok(Some(serialize::json::json!({
+                "exampleProperty": "running",
+            })))
+        }
+        .boxed_local()
     }
 
     fn stop<'a>(&mut self, _: &mut Context<Self>) -> EmptyResponse<'a> {

--- a/examples/example-runtime/src/main.rs
+++ b/examples/example-runtime/src/main.rs
@@ -1,17 +1,13 @@
-use futures::channel::oneshot;
 use futures::FutureExt;
 use serde::{Deserialize, Serialize};
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering::Relaxed;
 use structopt::StructOpt;
-use ya_runtime_sdk::serialize::json;
 use ya_runtime_sdk::*;
 
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]
 pub struct ExampleCli {
     #[allow(unused)]
-    example_path: Option<std::path::PathBuf>,
+    path: Option<std::path::PathBuf>,
 }
 
 #[derive(Default, Deserialize, Serialize)]
@@ -22,26 +18,26 @@ pub struct ExampleConf {
 #[derive(Default, RuntimeDef)]
 #[cli(ExampleCli)]
 #[conf(ExampleConf)]
-pub struct ExampleRuntime {
-    seq: AtomicU64,
-}
+pub struct ExampleRuntime;
 
 impl Runtime for ExampleRuntime {
     fn deploy<'a>(&mut self, _: &mut Context<Self>) -> OutputResponse<'a> {
-        async move {
-            Ok(json::json!(
-                {
-                    "startMode":"blocking",
-                    "valid":{"Ok":""},
-                    "vols":[]
-                }
-            ))
-        }
-        .boxed_local()
+        // SDK will auto-generate the following code:
+        //
+        // async move {
+        //     Ok(Some(serialize::json::json!({
+        //         "startMode": "blocking",
+        //         "valid": {"Ok": ""},
+        //         "vols": []
+        //     })))
+        // }
+        // .boxed_local()
+
+        async move { Ok(None) }.boxed_local()
     }
 
     fn start<'a>(&mut self, _: &mut Context<Self>) -> OutputResponse<'a> {
-        async move { Ok(json::json!({})) }.boxed_local()
+        async move { Ok(None) }.boxed_local()
     }
 
     fn stop<'a>(&mut self, _: &mut Context<Self>) -> EmptyResponse<'a> {
@@ -54,32 +50,17 @@ impl Runtime for ExampleRuntime {
         _mode: RuntimeMode,
         ctx: &mut Context<Self>,
     ) -> ProcessIdResponse<'a> {
-        let seq = self.seq.fetch_add(1, Relaxed);
-        let mut emitter = ctx.emitter.clone().unwrap();
-        let (tx, rx) = oneshot::channel();
-
-        // handle execution in background
-        tokio::task::spawn_local(async move {
-            emitter.command_started(seq).await;
-
-            // unblock `run_command` execution and continue in background
-            let _ = tx.send(seq);
-
-            let stdout = format!("[{}] output for command: {:?}", seq, command)
-                .as_bytes()
-                .to_vec();
-
-            tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
-
-            emitter.command_stdout(seq, stdout).await;
-            emitter.command_stopped(seq, 0).await;
-        });
-
-        async move {
-            let _ = rx.await;
-            Ok(seq)
-        }
-        .boxed_local()
+        tokio::process::Command::new("echo")
+            .arg(command.bin)
+            .args(command.args.into_iter())
+            .spawn()
+            // use RunExt::handle_command to manage the future result **in background**
+            .as_command(ctx, |child, mut run_ctx| async move {
+                let output = child.wait_with_output().await?;
+                run_ctx.stdout(output.stdout).await;
+                run_ctx.stderr(output.stderr).await;
+                Ok(())
+            })
     }
 }
 

--- a/ya-runtime-sdk/src/common.rs
+++ b/ya-runtime-sdk/src/common.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 pub trait IntoVec<T> {
     fn into_vec(self) -> Vec<T>;
 }
@@ -14,8 +16,26 @@ impl<T> IntoVec<T> for Box<[T]> {
     }
 }
 
+impl<'a> IntoVec<u8> for &'a [u8] {
+    fn into_vec(self) -> Vec<u8> {
+        self.to_vec()
+    }
+}
+
 impl IntoVec<u8> for String {
     fn into_vec(self) -> Vec<u8> {
         self.into_bytes()
+    }
+}
+
+impl<'a> IntoVec<u8> for &'a str {
+    fn into_vec(self) -> Vec<u8> {
+        self.as_bytes().to_vec()
+    }
+}
+
+impl<'a> IntoVec<u8> for Cow<'a, str> {
+    fn into_vec(self) -> Vec<u8> {
+        self.as_bytes().to_vec()
     }
 }

--- a/ya-runtime-sdk/src/common.rs
+++ b/ya-runtime-sdk/src/common.rs
@@ -1,0 +1,21 @@
+pub trait IntoVec<T> {
+    fn into_vec(self) -> Vec<T>;
+}
+
+impl<T> IntoVec<T> for Vec<T> {
+    fn into_vec(self) -> Vec<T> {
+        self
+    }
+}
+
+impl<T> IntoVec<T> for Box<[T]> {
+    fn into_vec(self) -> Vec<T> {
+        self.into()
+    }
+}
+
+impl IntoVec<u8> for String {
+    fn into_vec(self) -> Vec<u8> {
+        self.into_bytes()
+    }
+}

--- a/ya-runtime-sdk/src/error.rs
+++ b/ya-runtime-sdk/src/error.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
+use std::io;
+
 use crate::ErrorResponse;
 use serde::Serialize;
-use std::collections::HashMap;
 
 #[derive(Clone, Debug, Serialize)]
 pub struct Error {
@@ -12,8 +14,18 @@ pub struct Error {
 impl Error {
     pub fn from_string(s: impl ToString) -> Self {
         Error {
-            code: -1,
+            code: 1,
             message: s.to_string(),
+            context: Default::default(),
+        }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Error {
+            code: e.raw_os_error().unwrap_or(1),
+            message: e.to_string(),
             context: Default::default(),
         }
     }

--- a/ya-runtime-sdk/src/lib.rs
+++ b/ya-runtime-sdk/src/lib.rs
@@ -6,6 +6,7 @@ pub use runner::{run, run_with};
 pub use runtime::*;
 
 pub mod cli;
+mod common;
 pub mod env;
 pub mod error;
 mod runner;

--- a/ya-runtime-sdk/src/runner.rs
+++ b/ya-runtime-sdk/src/runner.rs
@@ -51,12 +51,8 @@ pub async fn run_with<R: Runtime + 'static, E: Env>(env: E) -> anyhow::Result<()
                         emitter: ctx.emitter.clone(),
                     };
 
-                    {
-                        cmd_ctx.started().await;
-                        if let Some(out) = start.await.expect("Failed to start the runtime") {
-                            cmd_ctx.stdout(out.to_string()).await;
-                        }
-                        cmd_ctx.stopped(0).await;
+                    if let Some(out) = start.await.expect("Failed to start the runtime") {
+                        cmd_ctx.stdout(out.to_string()).await;
                     }
 
                     Server::new(runtime, ctx)

--- a/ya-runtime-sdk/src/runner.rs
+++ b/ya-runtime-sdk/src/runner.rs
@@ -17,14 +17,27 @@ pub async fn run_with<R: Runtime + 'static, E: Env>(env: E) -> anyhow::Result<()
     let mut ctx = Context::<R>::try_with(env)?;
 
     match ctx.cli.command() {
-        Command::Deploy { args: _ } => {
-            let deployment = runtime.deploy(&mut ctx).await?;
+        Command::Deploy { .. } => {
+            let deployment = match runtime.deploy(&mut ctx).await? {
+                Some(deployment) => deployment,
+                None => {
+                    crate::serialize::json::json!({
+                        "startMode": match R::MODE {
+                            RuntimeMode::Server => "blocking",
+                            RuntimeMode::Command => "empty",
+                        },
+                        "valid": {"Ok": ""},
+                        "vols": []
+                    })
+                }
+            };
             output(deployment).await?;
         }
-        Command::Start { args: _ } => match R::MODE {
+        Command::Start { .. } => match R::MODE {
             RuntimeMode::Command => {
-                let started = runtime.start(&mut ctx).await?;
-                output(started).await?;
+                if let Some(started) = runtime.start(&mut ctx).await? {
+                    output(started).await?;
+                }
             }
             RuntimeMode::Server => {
                 ya_runtime_api::server::run_async(|emitter| async move {
@@ -62,11 +75,12 @@ pub async fn run_with<R: Runtime + 'static, E: Env>(env: E) -> anyhow::Result<()
 
             output(serde_json::json!(pid)).await?;
         }
-        Command::OfferTemplate { args: _ } => {
-            let template = runtime.offer(&mut ctx).await?;
-            output(template).await?;
+        Command::OfferTemplate { .. } => {
+            if let Some(template) = runtime.offer(&mut ctx).await? {
+                output(template).await?;
+            }
         }
-        Command::Test { args: _ } => runtime.test(&mut ctx).await?,
+        Command::Test { .. } => runtime.test(&mut ctx).await?,
     }
 
     Ok(())

--- a/ya-runtime-sdk/src/runtime.rs
+++ b/ya-runtime-sdk/src/runtime.rs
@@ -279,8 +279,8 @@ where
 /// Command execution handler
 #[derive(Clone)]
 pub struct RunCommandContext {
-    id: ProcessId,
-    emitter: Option<EventEmitter>,
+    pub(crate) id: ProcessId,
+    pub(crate) emitter: Option<EventEmitter>,
 }
 
 impl RunCommandContext {
@@ -289,7 +289,7 @@ impl RunCommandContext {
         &self.id
     }
 
-    fn started(&mut self) -> BoxFuture<()> {
+    pub(crate) fn started(&mut self) -> BoxFuture<()> {
         let id = self.id;
         self.emitter
             .as_mut()
@@ -297,7 +297,7 @@ impl RunCommandContext {
             .unwrap_or_else(|| futures::future::ready(()).boxed())
     }
 
-    fn stopped(&mut self, return_code: i32) -> BoxFuture<()> {
+    pub(crate) fn stopped(&mut self, return_code: i32) -> BoxFuture<()> {
         let id = self.id;
         self.emitter
             .as_mut()

--- a/ya-runtime-sdk/src/runtime.rs
+++ b/ya-runtime-sdk/src/runtime.rs
@@ -216,16 +216,22 @@ impl<R: Runtime + ?Sized> Context<R> {
     }
 }
 
+/// Command execution wrapper for use within `Runtime::run_command`
 pub trait RunCommandExt<R, F, T>
 where
     R: Runtime + ?Sized,
     F: Future<Output = Result<(), Error>> + 'static,
     T: 'static,
 {
+    /// Inlines `Self::command`
     fn as_command<'a, H>(self, ctx: &mut Context<R>, handler: H) -> ProcessIdResponse<'a>
     where
         H: (FnOnce(T, RunCommandContext) -> F) + 'a;
 
+    /// Wraps the command lifecycle in the following manner:
+    /// - manages command sequence numbers
+    /// - emits command start & stop events
+    /// - provides a RunCommandContext object for easier output event emission
     fn command<'a, H, Fi, Ei>(ctx: &mut Context<R>, fut: Fi, handler: H) -> ProcessIdResponse<'a>
     where
         H: (FnOnce(T, RunCommandContext) -> F) + 'a,

--- a/ya-runtime-sdk/src/runtime.rs
+++ b/ya-runtime-sdk/src/runtime.rs
@@ -1,12 +1,16 @@
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering::Relaxed;
 
 use futures::channel::mpsc;
 use futures::future::{BoxFuture, LocalBoxFuture};
-use futures::{FutureExt, SinkExt, StreamExt};
+use futures::{Future, FutureExt, SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use structopt::StructOpt;
 
 use crate::cli::CommandCli;
+use crate::common::IntoVec;
 use crate::env::{DefaultEnv, Env};
 use crate::error::Error;
 use crate::runtime_api::server::RuntimeEvent;
@@ -14,7 +18,7 @@ use crate::{KillProcess, ProcessStatus, RunProcess};
 
 pub type ProcessId = u64;
 pub type EmptyResponse<'a> = LocalBoxFuture<'a, Result<(), Error>>;
-pub type OutputResponse<'a> = LocalBoxFuture<'a, Result<serde_json::Value, Error>>;
+pub type OutputResponse<'a> = LocalBoxFuture<'a, Result<Option<serde_json::Value>, Error>>;
 pub type ProcessIdResponse<'a> = LocalBoxFuture<'a, Result<ProcessId, Error>>;
 
 /// Command handling interface for runtimes
@@ -50,10 +54,10 @@ pub trait Runtime: RuntimeDef + Default {
     /// Output a market Offer template stub
     fn offer<'a>(&mut self, _ctx: &mut Context<Self>) -> OutputResponse<'a> {
         async move {
-            Ok(crate::serialize::json::json!({
+            Ok(Some(crate::serialize::json::json!({
                 "constraints": "",
                 "properties": {}
-            }))
+            })))
         }
         .boxed_local()
     }
@@ -99,21 +103,8 @@ pub struct Context<R: Runtime + ?Sized> {
     /// and
     /// `command != Command::Deploy`
     pub emitter: Option<EventEmitter>,
-}
-
-impl<R: Runtime + ?Sized> Clone for Context<R>
-where
-    <R as RuntimeDef>::Cli: Clone,
-    <R as RuntimeDef>::Conf: Clone,
-{
-    fn clone(&self) -> Self {
-        Context {
-            cli: self.cli.clone(),
-            conf: self.conf.clone(),
-            conf_path: self.conf_path.clone(),
-            emitter: self.emitter.clone(),
-        }
-    }
+    /// Process ID sequence
+    pid_seq: AtomicU64,
 }
 
 impl<R: Runtime + ?Sized> Context<R> {
@@ -148,6 +139,7 @@ impl<R: Runtime + ?Sized> Context<R> {
             conf,
             conf_path,
             emitter: None,
+            pid_seq: Default::default(),
         })
     }
 
@@ -215,8 +207,123 @@ impl<R: Runtime + ?Sized> Context<R> {
         Ok(conf_path)
     }
 
+    pub(crate) fn next_pid(&self) -> ProcessId {
+        self.pid_seq.fetch_add(1, Relaxed)
+    }
+
     pub(crate) fn set_emitter(&mut self, emitter: impl RuntimeEvent + Send + Sync + 'static) {
         self.emitter.replace(EventEmitter::spawn(emitter));
+    }
+}
+
+pub trait RunCommandExt<R, F, T>
+where
+    R: Runtime + ?Sized,
+    F: Future<Output = Result<(), Error>> + 'static,
+    T: 'static,
+{
+    fn as_command<'a, H>(self, ctx: &mut Context<R>, handler: H) -> ProcessIdResponse<'a>
+    where
+        H: (FnOnce(T, RunCommandContext) -> F) + 'a;
+
+    fn command<'a, H, Fi, Ei>(ctx: &mut Context<R>, fut: Fi, handler: H) -> ProcessIdResponse<'a>
+    where
+        H: (FnOnce(T, RunCommandContext) -> F) + 'a,
+        Fi: Future<Output = Result<T, Ei>> + 'a,
+        Error: From<Ei>,
+    {
+        let pid = ctx.next_pid();
+        let mut cmd_ctx = RunCommandContext {
+            id: pid,
+            emitter: ctx.emitter.clone(),
+        };
+
+        async move {
+            let val = fut.await?;
+            cmd_ctx.started().await;
+
+            let fut = handler(val, cmd_ctx.clone());
+            tokio::task::spawn_local(async move {
+                let return_code = fut.await.is_err() as i32;
+                cmd_ctx.stopped(return_code).await;
+            });
+
+            Ok(pid)
+        }
+        .boxed_local()
+    }
+}
+
+impl<R, F, T, E> RunCommandExt<R, F, T> for Result<T, E>
+where
+    R: Runtime + ?Sized,
+    F: Future<Output = Result<(), Error>> + 'static,
+    T: 'static,
+    E: 'static,
+    Error: From<E>,
+{
+    fn as_command<'a, H>(self, ctx: &mut Context<R>, handler: H) -> ProcessIdResponse<'a>
+    where
+        H: (FnOnce(T, RunCommandContext) -> F) + 'a,
+    {
+        Self::command(ctx, async move { self }, handler)
+    }
+}
+
+/// Command execution handler
+#[derive(Clone)]
+pub struct RunCommandContext {
+    id: ProcessId,
+    emitter: Option<EventEmitter>,
+}
+
+impl RunCommandContext {
+    /// Get command ID
+    pub fn id(&self) -> &ProcessId {
+        &self.id
+    }
+
+    fn started(&mut self) -> BoxFuture<()> {
+        let id = self.id;
+        self.emitter
+            .as_mut()
+            .map(|e| e.command_started(id))
+            .unwrap_or_else(|| futures::future::ready(()).boxed())
+    }
+
+    fn stopped(&mut self, return_code: i32) -> BoxFuture<()> {
+        let id = self.id;
+        self.emitter
+            .as_mut()
+            .map(|e| e.command_stopped(id, return_code))
+            .unwrap_or_else(|| futures::future::ready(()).boxed())
+    }
+
+    /// Emit a RUN command output event (stdout)
+    pub fn stdout(&mut self, output: impl IntoVec<u8>) -> BoxFuture<()> {
+        let id = self.id;
+        let output = output.into_vec();
+        match self.emitter {
+            Some(ref mut e) => e.command_stdout(id, output),
+            None => Self::print_output(output),
+        }
+    }
+
+    /// Emit a RUN command output event (stderr)
+    pub fn stderr(&mut self, output: impl IntoVec<u8>) -> BoxFuture<()> {
+        let id = self.id;
+        let output = output.into_vec();
+        match self.emitter {
+            Some(ref mut e) => e.command_stderr(id, output),
+            None => Self::print_output(output),
+        }
+    }
+
+    fn print_output<'a>(output: impl IntoVec<u8>) -> BoxFuture<'a, ()> {
+        let mut stdout = std::io::stdout();
+        let _ = stdout.write_all(output.into_vec().as_slice());
+        let _ = stdout.flush();
+        futures::future::ready(()).boxed()
     }
 }
 
@@ -258,24 +365,32 @@ impl EventEmitter {
     }
 
     /// Emit a command output event (stdout)
-    pub fn command_stdout(&mut self, process_id: ProcessId, stdout: Vec<u8>) -> BoxFuture<()> {
+    pub fn command_stdout(
+        &mut self,
+        process_id: ProcessId,
+        stdout: impl IntoVec<u8>,
+    ) -> BoxFuture<()> {
         self.emit(ProcessStatus {
             pid: process_id,
             running: true,
             return_code: 0,
-            stdout,
+            stdout: stdout.into_vec(),
             stderr: Default::default(),
         })
     }
 
     /// Emit a command output event (stderr)
-    pub fn command_stderr(&mut self, process_id: ProcessId, stderr: Vec<u8>) -> BoxFuture<()> {
+    pub fn command_stderr(
+        &mut self,
+        process_id: ProcessId,
+        stderr: impl IntoVec<u8>,
+    ) -> BoxFuture<()> {
         self.emit(ProcessStatus {
             pid: process_id,
             running: true,
             return_code: 0,
             stdout: Default::default(),
-            stderr,
+            stderr: stderr.into_vec(),
         })
     }
 


### PR DESCRIPTION
- facilitates the command execution lifecycle. See the doc comments for `RunCommandExt` and the updated service example
- fix: emit output of the start command